### PR TITLE
Option to push current character to top of default table view

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -217,7 +217,6 @@ function Main:Render()
           function() return Data.db.global.currentfirst end,
           function()
             Data.db.global.currentfirst = not Data.db.global.currentfirst
-            LibDBIcon:Refresh(addonName, Data.db.global.currentfirst)
           end
         )
         currentCharacterFirst:SetTooltip(function(tooltip, elementDescription)

--- a/Main.lua
+++ b/Main.lua
@@ -212,6 +212,19 @@ function Main:Render()
           GameTooltip_AddNormalLine(tooltip, "No more moving the button around accidentally!");
         end)
 
+        local currentCharacterFirst = rootMenu:CreateCheckbox(
+          "Show current character first",
+          function() return Data.db.global.currentfirst end,
+          function()
+            Data.db.global.currentfirst = not Data.db.global.currentfirst
+            LibDBIcon:Refresh(addonName, Data.db.global.currentfirst)
+          end
+        )
+        currentCharacterFirst:SetTooltip(function(tooltip, elementDescription)
+          GameTooltip_SetTitle(tooltip, MenuUtil.GetElementText(elementDescription));
+          GameTooltip_AddNormalLine(tooltip, "Default view only. Sorting the table will still behave normally.");
+        end)
+
         rootMenu:CreateTitle("Window")
         local windowScale = rootMenu:CreateButton("Scaling")
         for i = 80, 200, 10 do

--- a/Table.lua
+++ b/Table.lua
@@ -93,7 +93,7 @@ function Table:CreateFrame(config)
   tableFrame.rows = {}
   tableFrame.data = tableFrame.config.data
   ---@type WK_TableSortState
-  tableFrame.sortState = {columnId = nil, direction = nil, isDefault = true}
+  tableFrame.sortState = {columnId = nil, direction = nil, isDefault = addon.Data.db.global.currentfirst}
 
   ---@param columnId string?
   ---@return number|nil
@@ -119,7 +119,7 @@ function Table:CreateFrame(config)
       state.columnId = nil
       state.direction = nil
     end
-    state.isDefault = true
+    state.isDefault = addon.Data.db.global.currentfirst
   end
 
   function tableFrame:ValidateSortState()

--- a/Table.lua
+++ b/Table.lua
@@ -191,7 +191,7 @@ function Table:CreateFrame(config)
       dataRows[#dataRows + 1] = rows[i]
     end
 
-	local currentCharacter = addon.Data:GetCharacter()  -- current character
+    local currentCharacter = addon.Data:GetCharacter()  -- current character
 
     ---@param row WK_TableRow
     ---@param colIndex number
@@ -212,23 +212,22 @@ function Table:CreateFrame(config)
       return getSortValueFromColumn(row, sortColumnIndex)
     end
 
-	---@param row WK_TableRow
+    ---@param row WK_TableRow
     local function isCurrentCharacter(row)
-	  local nameValue = row.data.character.name
+      local nameValue = row.data.character.name
       if not nameValue then return false end
       return tostring(nameValue):lower() == tostring(currentCharacter.name):lower()
     end
 
     table.sort(dataRows, function(a, b)
-	  if state.isDefault then
-	    local aIsCurrent = isCurrentCharacter(a)
+      if state.isDefault then
+        local aIsCurrent = isCurrentCharacter(a)
         local bIsCurrent = isCurrentCharacter(b)
 
-         -- Current character always on top
         if aIsCurrent and not bIsCurrent then return true end
         if not aIsCurrent and bIsCurrent then return false end
         if aIsCurrent and bIsCurrent then return false end
-	  end
+      end
 
       local va = getSortValue(a)
       local vb = getSortValue(b)

--- a/Table.lua
+++ b/Table.lua
@@ -277,7 +277,7 @@ function Table:CreateFrame(config)
       state.columnId = columnId
       state.direction = "desc"
     end
-	state.isDefault = false
+    state.isDefault = false
     self:ApplySortToData()
     self:RenderTable()
     notifySortStateChanged()

--- a/Table.lua
+++ b/Table.lua
@@ -93,7 +93,7 @@ function Table:CreateFrame(config)
   tableFrame.rows = {}
   tableFrame.data = tableFrame.config.data
   ---@type WK_TableSortState
-  tableFrame.sortState = {columnId = nil, direction = nil}
+  tableFrame.sortState = {columnId = nil, direction = nil, isDefault = true}
 
   ---@param columnId string?
   ---@return number|nil
@@ -119,6 +119,7 @@ function Table:CreateFrame(config)
       state.columnId = nil
       state.direction = nil
     end
+    state.isDefault = true
   end
 
   function tableFrame:ValidateSortState()
@@ -190,6 +191,8 @@ function Table:CreateFrame(config)
       dataRows[#dataRows + 1] = rows[i]
     end
 
+	local currentCharacter = addon.Data:GetCharacter()  -- current character
+
     ---@param row WK_TableRow
     ---@param colIndex number
     local function getSortValueFromColumn(row, colIndex)
@@ -209,7 +212,24 @@ function Table:CreateFrame(config)
       return getSortValueFromColumn(row, sortColumnIndex)
     end
 
+	---@param row WK_TableRow
+    local function isCurrentCharacter(row)
+	  local nameValue = row.data.character.name
+      if not nameValue then return false end
+      return tostring(nameValue):lower() == tostring(currentCharacter.name):lower()
+    end
+
     table.sort(dataRows, function(a, b)
+	  if state.isDefault then
+	    local aIsCurrent = isCurrentCharacter(a)
+        local bIsCurrent = isCurrentCharacter(b)
+
+         -- Current character always on top
+        if aIsCurrent and not bIsCurrent then return true end
+        if not aIsCurrent and bIsCurrent then return false end
+        if aIsCurrent and bIsCurrent then return false end
+	  end
+
       local va = getSortValue(a)
       local vb = getSortValue(b)
       if type(va) == "number" and type(vb) == "number" then
@@ -257,6 +277,7 @@ function Table:CreateFrame(config)
       state.columnId = columnId
       state.direction = "desc"
     end
+	state.isDefault = false
     self:ApplySortToData()
     self:RenderTable()
     notifySortStateChanged()


### PR DESCRIPTION
I noticed #144 and have also missed the default behavior of your currently logged in character being pushed to the top of the main WeeklyKnowledge table.

I haven't really messed around with Lua so I wasn't able to make it a config option or anything like that, but I whipped up a quick version of `Table.lua` that will provide this default behavior. When you first load into a character or right click a column name to restore the default view, this will push your current character to the top of the list. If you left click any column, the current sorting logic will win out and it should behave the same way as it has been since sorting was first implemented.

I just wanted to create this PR to have a record of the changes I made to my local version and/or provide a starting point for this feature request if you prefer to make it a configuration option instead of a hard-coded default. I personally prefer it this way, but other users' mileage may vary. Thanks!

Update: Made it a configuration option instead of a hard-coded "true." It should be off by default but can be toggled into an "on" state. Let me know if it works okay for you:

<img width="732" height="411" alt="image" src="https://github.com/user-attachments/assets/4cdf7bfd-bc5c-4d60-b177-6f67152688bf" />