### PR TITLE
Fix missing gathering quest IDs

### DIFF
--- a/Data/Objectives/CatchUp.lua
+++ b/Data/Objectives/CatchUp.lua
@@ -51,9 +51,9 @@ local objectives = {
   -- Midnight: Leatherworking
   {skillLineVariantID = 2915, categoryID = category, quests = {}, itemID = 246332, points = 0, loc = {hint = "Awarded from Patron Orders at your crafting station."}},
   -- Midnight: Mining
-  {skillLineVariantID = 2916, categoryID = category, quests = {}, itemID = 237507, points = 0, loc = {hint = "These are randomly looted from mining nodes around the world once the weekly objectives below are completed."}, requires = {{type = "quest", name = "Trainer Quest", quests = {93709, 93708, 93706, 93705}, match = "any"}, {type = "quest", name = "Gathering", quests = {88673, 88674, 88675, 88676, 88677, 88678}, match = "all"}}},
+  {skillLineVariantID = 2916, categoryID = category, quests = {}, itemID = 237507, points = 0, loc = {hint = "These are randomly looted from mining nodes around the world once the weekly objectives below are completed."}, requires = {{type = "quest", name = "Trainer Quest", quests = {93709, 93708, 93707, 93706, 93705}, match = "any"}, {type = "quest", name = "Gathering", quests = {88673, 88674, 88675, 88676, 88677, 88678}, match = "all"}}},
   -- Midnight: Skinning
-  {skillLineVariantID = 2917, categoryID = category, quests = {}, itemID = 238627, points = 0, loc = {hint = "These are randomly looted from skinning around the world once the weekly objectives below are completed."},     requires = {{type = "quest", name = "Trainer Quest", quests = {93714, 93711, 93710}, match = "any"}, {type = "quest", name = "Gathering", quests = {88534, 88549, 88537, 88536, 88530, 88529}, match = "all"}}},
+  {skillLineVariantID = 2917, categoryID = category, quests = {}, itemID = 238627, points = 0, loc = {hint = "These are randomly looted from skinning around the world once the weekly objectives below are completed."},     requires = {{type = "quest", name = "Trainer Quest", quests = {93714, 93713, 93712, 93711, 93710}, match = "any"}, {type = "quest", name = "Gathering", quests = {88534, 88549, 88537, 88536, 88530, 88529}, match = "all"}}},
   -- Midnight: Tailoring
   {skillLineVariantID = 2918, categoryID = category, quests = {}, itemID = 246334, points = 0, loc = {hint = "Awarded from Patron Orders at your crafting station."}},
 }

--- a/Data/Objectives/WeeklyQuest.lua
+++ b/Data/Objectives/WeeklyQuest.lua
@@ -51,9 +51,9 @@ local objectives = {
   -- Midnight: Leatherworking
   {skillLineVariantID = 2915, categoryID = category, quests = {93695},                             itemID = 263459, points = 2, loc = {m = Enum.WK_Map.SilvermoonCity, x = 45.0, y = 55.2, hint = "Complete a quest from the Artisan's Consortium."}},
   -- Midnight: Mining
-  {skillLineVariantID = 2916, categoryID = category, quests = {93705, 93706, 93708, 93709},        itemID = 263463, points = 3, limit = 1,                                                                                                                      loc = {m = Enum.WK_Map.SilvermoonCity, x = 42.6, y = 52.8, hint = "Complete a quest from |cffffff00Belil|r <Mining Trainer>."}},
+  {skillLineVariantID = 2916, categoryID = category, quests = {93705, 93706, 93707, 93708, 93709}, itemID = 263463, points = 3, limit = 1,                                                                                                                      loc = {m = Enum.WK_Map.SilvermoonCity, x = 42.6, y = 52.8, hint = "Complete a quest from |cffffff00Belil|r <Mining Trainer>."}},
   -- Midnight: Skinning
-  {skillLineVariantID = 2917, categoryID = category, quests = {93710, 93711, 93712, 93714},        itemID = 263461, points = 3, limit = 1,                                                                                                                      loc = {m = Enum.WK_Map.SilvermoonCity, x = 43.2, y = 55.6, hint = "Complete a quest from |cffffff00Tyn|r <Skinning Trainer>."}},
+  {skillLineVariantID = 2917, categoryID = category, quests = {93710, 93711, 93712, 93713, 93714}, itemID = 263461, points = 3, limit = 1,                                                                                                                      loc = {m = Enum.WK_Map.SilvermoonCity, x = 43.2, y = 55.6, hint = "Complete a quest from |cffffff00Tyn|r <Skinning Trainer>."}},
   -- Midnight: Tailoring
   {skillLineVariantID = 2918, categoryID = category, quests = {93696},                             itemID = 263460, points = 2, loc = {m = Enum.WK_Map.SilvermoonCity, x = 45.0, y = 55.2, hint = "Complete a quest from the Artisan's Consortium."}},
 }


### PR DESCRIPTION
Adds missing mining quest ID `93707` and missing skinning quest ID `93713`. Skinning quest ID `93712` was also missing from the CatchUp file.