### PR TITLE
Always apply table columns before setting data

### DIFF
--- a/Modules/Main/Module.lua
+++ b/Modules/Main/Module.lua
@@ -296,6 +296,7 @@ function Main:Render()
     end)
   end
 
+  self:ApplyTableColumns()
   self.window.table:SetData(rows)
 
   local minWindowWidth = 500


### PR DESCRIPTION
My attempt at fixing issue #155. It seems like there could be an issue where some version of the table being built prior to the faire can end up out of sync with the data within. It might not be the best or most efficient solve, but it did get all the columns to render correctly for me once again.